### PR TITLE
fixed error with jQuery Tools detection when using jQuery.noConflict()

### DIFF
--- a/library/libraries.js
+++ b/library/libraries.js
@@ -437,8 +437,8 @@ var d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests = {
 	   url: 'http://flowplayer.org/tools',
 	   test: function(win) {
             var jq = win.jQuery || win.$;
-            if(jq && win.$.tools) {
-	           return { version: $.tools.version };
+            if(jq && jq.tools) {
+	           return { version: jq.tools.version };
 	       }
 	       return false;
 	   }


### PR DESCRIPTION
fixed error with jQuery Tools detection when using jQuery.noConflict(): "Uncaught TypeError: Cannot read property 'tools' of undefined"

Hi Andrew,

Let me know if you have any questions. Seems like a pretty straightforward fix. Must have been an oversight.
