### PR TITLE
Fix Velocity.js detection

### DIFF
--- a/library/libraries.js
+++ b/library/libraries.js
@@ -858,13 +858,15 @@ var d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests = {
         icon: 'icon_48',
         url: 'http://velocityjs.org/',
         test: function(win) {
-            var jq = win.jQuery || win.$;
-            if(jq && jq.Velocity) {
+            var jq = win.jQuery || win.$,
+                velocity = jq ? jq.Velocity : win.Velocity;
+
+            if(velocity) {
                 return { 
                     version: 
-                        jq.Velocity.State.version.major + "." +
-                        jq.Velocity.State.version.minor + "." +
-                        jq.Velocity.State.version.patch
+                        velocity.version.major + "." +
+                        velocity.version.minor + "." +
+                        velocity.version.patch
                 };
             }
             return false;


### PR DESCRIPTION
Read Velocity.js version info from the right object, and make sure it works also in standalone mode.

Tested with all Velocity.js versions from 0.5.0 to 1.1.0. The most recent versions were also tested with both jQuery and Zepto, and (since 1.0.0) in standalone mode (no jQuery or Zepto present).
