### PR TITLE
Catch errors from broken tests

### DIFF
--- a/content_scripts/lib_detect.js
+++ b/content_scripts/lib_detect.js
@@ -21,12 +21,16 @@
             var tests = d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests;
             var libraries = [];
             for (var i in tests) {
-                var result = tests[i].test(window);
-                if (result === false) continue;
-                libraries.push({
-                    name: i,
-                    version: result.version
-                });
+                try {
+                    var result = tests[i].test(window);
+                    if (result === false) continue;
+                    libraries.push({
+                        name: i,
+                        version: result.version
+                    });
+                } catch(e) {
+                    console.log('Library Detector test for ' + i + ' failed:', e);
+                }
             }
             return libraries;
         };


### PR DESCRIPTION
Currently, a broken test will throw a top-level exception, which is not a nice thing for an extension to do to a host page.  With this change any test exceptions will be caught and reported to the console instead.

The fix is prompted by Library Detector's broken Velocity.js detector currently crashing my site https://reviewable.io, which purposely halts the app if a top-level exception (presumed to be from the app) is detected.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/andrewbredow/library-detector-for-chrome/63)

<!-- Reviewable:end -->
