### PR TITLE
Bug fix for Library Detector test for Material Design Lite failed

### DIFF
--- a/library/libraries.js
+++ b/library/libraries.js
@@ -1024,8 +1024,9 @@ var d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests = {
     	url: 'http://www.getmdl.io/',
     	test: function(win) {
     		if(win.componentHandler && win.componentHandler.upgradeElement) {
-    			return { version: 'N/A'}
+    			return { version: 'N/A'};
     		}
+    		return false;
     	}
     },
     'Kendo UI': {


### PR DESCRIPTION
Fix Type Error: unknown property 'version' while checking for Material Design Lite.