### PR TITLE
Add and update library tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ supports:
 - [Spine](http://spinejs.com/)
 - [SproutCore](http://sproutcore.com/)
 - [Spry](https://github.com/adobe/Spry)
+- [SWFObject](https://github.com/swfobject/swfobject)
 - [Swiffy](https://developers.google.com/swiffy/)
 - [Three.js](http://threejs.org/)
 - [Tween.js](https://github.com/tweenjs/tween.js)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ supports:
 - [Ember.js](http://emberjs.com/)
 - [Ext JS](https://www.sencha.com/products/extjs/)
 - [Fabric.js](http://fabricjs.com/)
+- [FlexSlider](https://woocommerce.com/flexslider/)
 - [Flot Charts](http://www.flotcharts.org/)
 - [Foundation](http://foundation.zurb.com/)
 - [FuseJS](http://kiro.me/projects/fuse.html)

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ supports:
 - [MooTools](http://mootools.net/)
 - [Move.js](https://visionmedia.github.io/move.js/)
 - [Mustache.js](https://mustache.github.io/)
+- [Numeral.js](http://numeraljs.com/)
 - [Paper.js](http://paperjs.org/)
 - [PhiloGL](http://www.senchalabs.org/philogl/)
 - [Pixi.js](http://www.pixijs.com/)

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ supports:
 - [MochiKit](http://mochi.github.io/mochikit/)
 - [Modernizr](http://modernizr.com/)
 - [Moment.js](http://momentjs.com/)
+- [Moment Timezone](http://momentjs.com/timezone/)
 - [MooTools](http://mootools.net/)
 - [Move.js](https://visionmedia.github.io/move.js/)
 - [Mustache.js](https://mustache.github.io/)

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ supports:
 - [Script.aculo.us](https://script.aculo.us/)
 - [Sea.js](http://seajs.org/)
 - [Socket.IO](http://socket.io/)
+- [SPF](https://youtube.github.io/spfjs/)
 - [Spine](http://spinejs.com/)
 - [SproutCore](http://sproutcore.com/)
 - [Spry](https://github.com/adobe/Spry)

--- a/library/libraries.js
+++ b/library/libraries.js
@@ -1073,8 +1073,9 @@ var d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests = {
         icon: 'momentjs',
         url: 'http://momentjs.com/',
         test: function(win) {
-            if(win.moment && win.moment.isMoment) {
-                return { version: win.moment.version };
+            if(win.moment && (win.moment.isMoment || win.moment.lang)) {
+                // version 1.0.0 has neither "isMoment" nor "version"
+                return { version: win.moment.version || null };
             }
             return false;
         }

--- a/library/libraries.js
+++ b/library/libraries.js
@@ -1080,6 +1080,16 @@ var d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests = {
             return false;
         }
     },
+    'Moment Timezone': {
+        icon: 'momentjs',
+        url: 'http://momentjs.com/timezone/',
+        test: function(win) {
+            if (win.moment && win.moment.tz) {
+                return { version: win.moment.tz.version || null };
+            }
+            return false;
+        }
+    },
     'ScrollMagic': {
         icon: 'scrollmagic',
         url: 'http://scrollmagic.io/',

--- a/library/libraries.js
+++ b/library/libraries.js
@@ -406,8 +406,9 @@ var d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests = {
         icon: 'leaflet',
         url: 'http://leafletjs.com',
         test: function(win) {
-            if (win.L && win.L.GeoJSON && win.L.marker) {
-                return {version: win.L.version};
+            // Leaflet 3.1 uses L.Marker and L.VERSION; later versions use L.marker and L.version
+            if (win.L && win.L.GeoJSON && (win.L.marker || win.L.Marker)) {
+                return { version: win.L.version || win.L.VERSION || null };
             }
             return false;
         }

--- a/library/libraries.js
+++ b/library/libraries.js
@@ -1088,5 +1088,19 @@ var d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests = {
             }
             return false;
         }
+    },
+    'SWFObject': {
+        icon: 'icon_48', // currently has no icon
+        url: 'https://github.com/swfobject/swfobject',
+        test: function(win) {
+            if (win.swfobject && win.swfobject.embedSWF) {
+                // 2.x - exact version only for 2.3
+                return { version: win.swfobject.version || null };
+            } else if(win.deconcept && win.deconcept.SWFObject) {
+                // 1.x
+                return { version: null };
+            }
+            return false;
+        }
     }
 };

--- a/library/libraries.js
+++ b/library/libraries.js
@@ -517,7 +517,8 @@ var d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests = {
         icon: 'socketio', // currently has no icon
         url: 'http://socket.io',
         test: function(win) {
-            if (win.io && win.io.sockets && win.io.version) {
+            // version 0.6.2 uses only io.Socket; more recent versions also have io.sockets
+            if (win.io && (win.io.sockets || win.io.Socket) && win.io.version) {
                 return {version: win.io.version};
             }
             return false;

--- a/library/libraries.js
+++ b/library/libraries.js
@@ -1124,5 +1124,15 @@ var d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests = {
             }
             return false;
         }
+    },
+    'SPF': {
+        icon: 'icon_48', // currently has no icon
+        url: 'https://youtube.github.io/spfjs/',
+        test: function(win) {
+            if (win.spf && win.spf.init) {
+                return { version: null };
+            }
+            return false;
+        }
     }
 };

--- a/library/libraries.js
+++ b/library/libraries.js
@@ -1134,5 +1134,15 @@ var d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests = {
             }
             return false;
         }
+    },
+    'Numeral.js': {
+        icon: 'icon_48', // currently has no icon
+        url: 'http://numeraljs.com/',
+        test: function(win) {
+            if (win.numeral && win.isNumeral) {
+                return { version: win.numeral.version || null };
+            }
+            return false;
+        }
     }
 };

--- a/library/libraries.js
+++ b/library/libraries.js
@@ -1102,5 +1102,16 @@ var d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests = {
             }
             return false;
         }
+    },
+    'FlexSlider': {
+        icon: 'icon_48', // currently has no icon
+        url: 'https://woocommerce.com/flexslider/',
+        test: function(win) {
+            var jq = win.jQuery || win.$ || win.$jq || win.$j;
+            if (jq && jq.fn && jq.fn.jquery && jq.flexslider){
+                return { version: null };
+            }
+            return false;
+        }
     }
 };

--- a/library/libraries.js
+++ b/library/libraries.js
@@ -675,8 +675,9 @@ var d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests = {
         icon: 'requirejs',
         url: 'http://requirejs.org/',
         test: function(win) {
-            if ((win.require && win.require.load) || (win.requirejs && win.requirejs.load)) {
-                return {version: win.require.version || win.requirejs.version};
+            var req = win.require || win.requirejs;
+            if (req && (req.load || (req.s && req.s.contexts && req.s.contexts._ && (req.s.contexts._.loaded || req.s.contexts._.load)))) {
+                return { version: req.version || null };
             }
             return false;
         }

--- a/library/libraries.js
+++ b/library/libraries.js
@@ -923,8 +923,9 @@ var d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests = {
         url: 'https://github.com/GoodBoyDigital/pixi.js',
         test: function(win) {
             var px = win.PIXI;
-            if(px && px.VERSION) {
-                return { version: PIXI.VERSION.split('v')[1] };
+            if(px && px.WebGLRenderer && px.VERSION) {
+                // version 4.4.3 returns simply "4.4.3"; version 1.5.2 returns "v1.5.2"
+                return { version: px.VERSION.replace('v', '') || null };
             }
             return false;
         }


### PR DESCRIPTION
New tests for:
- SWFObject
- FlexSlider (plug-in for jQuery)
- Timezone (plug-in for Moment.js)
- SPF
- Numeral.js

Modified tests to include older versions and/or make them more robust:
- Moment.js
- Leaflet
- Socket.IO
- RequireJS
- Pixi.js

(This PR is for issue #89)