### PR TITLE
Add new react signal

### DIFF
--- a/library/libraries.js
+++ b/library/libraries.js
@@ -367,6 +367,9 @@ var d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests = {
             if (win.React && win.React.createClass) {
                 return { version: win.React.version || UNKNOWN_VERSION };
             }
+            if (win.__REACT_DEVTOOLS_GLOBAL_HOOK__) {
+                return { version: UNKNOWN_VERSION };
+            }
             return false;
         }
     },


### PR DESCRIPTION
Looking at a few of the sites here: https://github.com/facebook/react/wiki/sites-using-react, many of them do not actually expose `window.React`. Many do, however, expose `window.__REACT_DEVTOOLS_GLOBAL_HOOK__`. This PR adds that global object to the React test.