### PR TITLE
fix(libraries): expand react detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ supports:
 - [Cristian Douce](https://github.com/cristiandouce)
 - [Vinicius Reis](https://github.com/vinicius73)
 - [Rick Viscomi](https://github.com/rviscomi)
+- [Patrick Hulce](https://github.com/patrickhulce)
 
 ### Inspiration
 Library detection class inspired by [Paul Bakaus'](https://paulbakaus.com/) [Library Detector for Firefox](https://addons.mozilla.org/en-us/firefox/addon/library-detector/)

--- a/library/libraries.js
+++ b/library/libraries.js
@@ -378,7 +378,8 @@ var d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests = {
         npm: 'react',
         test: function(win) {
             var reactRoot = document.getElementById('react-root');
-            if (reactRoot && reactRoot.innerText.length > 0 || win.React && win.React.Component) {
+            var altHasReact = document.querySelector('*[data-reactroot]');
+            if (reactRoot && reactRoot.innerText.length > 0 || altHasReact || win.React && win.React.Component) {
                 return { version: win.React && win.React.version || UNKNOWN_VERSION };
             }
             return false;


### PR DESCRIPTION
currently the extension fails to detect many react sites (fails on first 6 demos of https://react.rocks/)

this expands the detection logic to look for presence of the data-reactroot attribute on an element which passes 5/6 demos