### PR TITLE
Fix Preact detection

### DIFF
--- a/library/libraries.js
+++ b/library/libraries.js
@@ -388,13 +388,13 @@ var d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests = {
             var expando = typeof Symbol!='undefined' && Symbol.for && Symbol.for('preactattr');
             function isPreactNode(node) {
                 if (node._component!=null || node.__preactattr_!=null || expando && node[expando]!=null) {
-                    return node;
+                    return true;
                 }
                 return null;
             }
             var preactRoot = isPreactNode(document.body) || isPreactNode(document.body.firstElementChild || {});
             if (!preactRoot) {
-                preactRoot = document.createTreeWalker(document.body, 3, isPreactNode).nextNode();
+                preactRoot = document.createTreeWalker(document.body, 1, isPreactNode).nextNode();
             }
             if (preactRoot || win.preact) {
                 var version = UNKNOWN_VERSION;


### PR DESCRIPTION
This fixes detection of Preact when not mounted directly at `<body>`.