### PR TITLE
Fix React detection

### DIFF
--- a/library/libraries.js
+++ b/library/libraries.js
@@ -372,7 +372,7 @@ var d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests = {
             var reactRoot = document.getElementById('react-root');
             var altHasReact = document.querySelector('*[data-reactroot]');
             var bodyReactRoot = isReactNode(document.body) || isReactNode(document.body.firstElementChild || {});
-            var hasReactRoot = bodyReactRoot|| document.createTreeWalker(document.body, 3, isReactNode).nextNode() != null;
+            var hasReactRoot = bodyReactRoot|| document.createTreeWalker(document.body, 1, isReactNode).nextNode() != null;
             if (hasReactRoot || reactRoot && reactRoot.innerText.length > 0 || altHasReact || win.React && win.React.Component) {
                 return { version: win.React && win.React.version || UNKNOWN_VERSION };
             }


### PR DESCRIPTION
This addresses the case where there are no attribute indicators present in the DOM, which results in a scan for `_reactRootContainer` properties. It was erroneously only scanning Text nodes, when it should have been scanning Elements.