### PR TITLE
removes secondary attr check from Nuxt detection

### DIFF
--- a/library/libraries.js
+++ b/library/libraries.js
@@ -1130,7 +1130,7 @@ var d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests = {
         url: 'https://nuxtjs.org/',
         npm: 'nuxt',
         test: function(win) {
-            if ((win.__NUXT__ && win.__NUXT__.data != null) || (win.$nuxt && win.$nuxt.nuxt)) {
+            if ((win.__NUXT__ && win.__NUXT__.data != null) || win.$nuxt) {
                 return { version: UNKNOWN_VERSION };
             }
             return false;


### PR DESCRIPTION
Per @pi0's suggestion [here](https://github.com/johnmichel/Library-Detector-for-Chrome/pull/129#pullrequestreview-210832465)