### PR TITLE
Fix detection for Preact X

### DIFF
--- a/library/libraries.js
+++ b/library/libraries.js
@@ -476,7 +476,10 @@ var d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests = {
         test: function(win) {
             var expando = typeof Symbol!='undefined' && Symbol.for && Symbol.for('preactattr');
             function isMatch(node) {
-                return node._component!=null || node.__preactattr_!=null || expando && node[expando]!=null;
+                if ('__k' in node && 'props' in node.__k && 'type' in node.__k) {
+                    return true;
+                }
+                return '_component' in node || '__preactattr_' in node || expando && node[expando]!=null;
             }
             function getMatch(node) {
                 return node!=null && isMatch(node) && node;
@@ -492,6 +495,9 @@ var d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests = {
                 var version = UNKNOWN_VERSION;
                 if (expando && preactRoot && preactRoot[expando]!=null) {
                     version = '7';
+                }
+                if (preactRoot && '__k' in preactRoot) {
+                    version = '10';
                 }
                 return { version: version };
             }


### PR DESCRIPTION
Examples:

| URL | Known to be using | Detection result
|-|-|-|
| twitter.com | not using | false
| preactjs.com | 10.0.5 | `{ version: "10" }`
| groupon.com | 10.0 | `{ version: "10" }`
| ride.lyft.com | 8.2 | `{ version: UNKNOWN_VERSION }`
| preact-www.surge.sh | 7.x | `{ version: "7" }`
| esbench.com | 3.0 | `{ version: UNKNOWN_VERSION }`
