### PR TITLE
improve core-js logic when multiple versions

### DIFF
--- a/library/libraries.js
+++ b/library/libraries.js
@@ -1695,7 +1695,7 @@ var d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests = {
             const core = win.core;
             if (shared) {
                 const versions = shared.versions;
-                return { version: Array.isArray(versions) ? versions.map(it => `${ it.version }: ${ it.mode }`).join(', ') : UNKNOWN_VERSION };
+                return { version: Array.isArray(versions) ? versions.map(it => `${ it.version } for ${ it.mode }`).join(' and ') : UNKNOWN_VERSION };
             } else if (core) {
                 return { version: core.version || UNKNOWN_VERSION };
             }

--- a/library/libraries.js
+++ b/library/libraries.js
@@ -1695,7 +1695,7 @@ var d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests = {
             const core = win.core;
             if (shared) {
                 const versions = shared.versions;
-                return { version: Array.isArray(versions) ? versions.map(it => `${ it.version } for ${ it.mode }`).join(' and ') : UNKNOWN_VERSION };
+                return { version: Array.isArray(versions) ? versions.map(it => `core-js-${ it.mode }@${ it.version }`).join('; ') : UNKNOWN_VERSION };
             } else if (core) {
                 return { version: core.version || UNKNOWN_VERSION };
             }


### PR DESCRIPTION
The detection has a problem with https://www.camdenmarket.com/visit-us and no libraries at all are listed for that URL.

This PR fixes that by removing the `:` and `,` from the returned version which caused problems for [parseLibraries() in main.js](https://github.com/johnmichel/Library-Detector-for-Chrome/blob/master/background_scripts/main.js#L13-L26) which splits using those characters.  I'm sure there's a cleaner/better way to this fix it but at least this makes the extension lists libraries.

cc: @zloirock who added the original core-js PR.