### PR TITLE
Updated Drupal detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ supports:
 - [D3](https://d3js.org/)
 - [DC.js](https://dc-js.github.io/dc.js/)
 - [Dojo](https://dojotoolkit.org/)
+- [Drupal](https://drupal.org/)
 - [Ember.js](https://emberjs.com/)
 - [Ext JS](https://www.sencha.com/products/extjs/)
 - [Fabric.js](http://fabricjs.com/)

--- a/library/libraries.js
+++ b/library/libraries.js
@@ -1739,11 +1739,18 @@ var d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests = {
         url: 'https://www.drupal.org/',
         npm: null,
         test: function (win) {
-            if (win.Drupal && win.Drupal.behaviors) {
-                const generatorMeta = document.querySelector('meta[name=Generator][content^="Drupal"]');
-                const version = generatorMeta ? generatorMeta.getAttribute("content").replace(/\D+/gi,'') : UNKNOWN_VERSION;
+            const generatorMeta = document.querySelector('meta[name=Generator][content^="Drupal"]');
+            const version = generatorMeta ? generatorMeta.getAttribute("content").replace(/\D+/gi,'') : UNKNOWN_VERSION;
+
+            // Detect Drupal resources patterns
+            const resDrupal = /\/sites\/(?:default|all)\/(?:themes|modules|files)/;
+            const res = Array.from(document.querySelectorAll('link,style,script') || []);
+
+            if (res.some(s => resDrupal.test(s.src)) || res.some(s => resDrupal.test(s.href)) ||
+                generatorMeta || (win.Drupal && win.Drupal.behaviors)) {
                 return { version };
             }
+
             return false;
         }
     }


### PR DESCRIPTION
The detection in #162 fails to detect Drupal sites without the loaded js `Drupal.behaviors`, for example: https://dri.es/ <- that's the Drupal website of the founder of the Drupal project.

This is an updated detection that checks for any of the following:
- Tries to detect the Drupal version from meta generator (same as the old PR #162 )
- Checks for `Drupal.behaviors` (same as the old PR #162 ) but doesn't fail detection if not found
- Checks for styles/scripts resources commonly known Drupal paths of `sites/(default|all)/(modules|themes|files)`