### PR TITLE
Fix AngularJS detection (false-positives)

### DIFF
--- a/library/libraries.js
+++ b/library/libraries.js
@@ -1121,11 +1121,8 @@ var d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests = {
         npm: 'angular',
         test: function(win) {
             var ng = win.angular;
-            if(ng && ng.version && ng.version.full) {
+            if (ng && ng.version && ng.version.full) {
                 return { version: ng.version.full };
-            }
-            else if (ng) {
-                return { version: UNKNOWN_VERSION };
             }
             return false;
         }


### PR DESCRIPTION
As the AngularJS from the beginning has versioning on its object I
removed the "else" condition. That else condition causes false-positives
on pages where the HTML element has id="angular" (or literal object name the same).