### PR TITLE
update detection logic for Nuxt

### DIFF
--- a/library/libraries.js
+++ b/library/libraries.js
@@ -1357,7 +1357,7 @@ var d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests = {
         url: 'https://nuxtjs.org/',
         npm: 'nuxt',
         test: function(win) {
-            if ((win.__NUXT__ && win.__NUXT__.data != null) || win.$nuxt) {
+            if (win.__NUXT__ || win.$nuxt || [...win.document.querySelectorAll('*')].some(el => el.__vue__?.nuxt)) {
                 return { version: UNKNOWN_VERSION };
             }
             return false;


### PR DESCRIPTION
Fix detection logic for Nuxt to identify both SPA and Universal mode.
This fix is recommended by the Nuxt team per the code below:
https://github.com/nuxtlabs/vue-telescope-analyzer/blob/3c88dabcbf8f6e1f8689ce0df86780a9aaa58a32/detectors/frameworks.json#L14

Fix https://github.com/johnmichel/Library-Detector-for-Chrome/issues/157