### PR TITLE
Ensure that response.libs is iterable

### DIFF
--- a/popups/libraries.js
+++ b/popups/libraries.js
@@ -25,7 +25,7 @@ var addLibrary = function(library) {
 
 (async () => {
     const response = await chrome.runtime.sendMessage({type: 'popup-request-libs'});
-    for (const lib of response.libs) {
+    for (const lib of Array.from(response.libs)) {
         addLibrary(lib);
     }
 })();


### PR DESCRIPTION
An error would occur when opening the popup; this ensures that the library data is iterable.